### PR TITLE
Latest guzzle promise dropped functions.php.

### DIFF
--- a/src/Helpers/Table.php
+++ b/src/Helpers/Table.php
@@ -179,7 +179,7 @@ class Table
         }
         call_user_func($flushCallback, 1);
 
-        \GuzzleHttp\Promise\each_limit(
+        \GuzzleHttp\Promise\Each::ofLimit(
             $promises,
             $concurrency,
             function (Result $result) use (&$unprocessed, &$returnSet) {
@@ -1109,7 +1109,7 @@ class Table
         }
         call_user_func($flushCallback, 1);
 
-        \GuzzleHttp\Promise\each_limit(
+        \GuzzleHttp\Promise\Each::ofLimit(
             $promises,
             $concurrency,
             function (Result $result) use ($isPut, &$unprocessed) {


### PR DESCRIPTION
The Each helper class has the same functionality and is in older releases of guzzle promise.